### PR TITLE
Assign PYTHONPATH instead of PYTHONUSERBASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This buildpack participates if `Pipfile` exists at the root the app.
 The buildpack will do the following:
 * At build time:
   - Installs the application packages to a layer made available to the app.
-  - Sets the `PYTHONUSERBASE` to this layer.
+  - Prepends the layer site-packages onto `PYTHONPATH`.
   - Prepends the layer's `bin` directory to the `PATH`.
 * At run time:
   - Does nothing
@@ -43,14 +43,14 @@ file that looks like the following:
   [requires.metadata]
 
     # Setting the build flag to true will ensure that the site-packages
-    # dependency is available on the $PYTHONUSERBASE/$PATH for subsequent
+    # dependency is available on the $PYTHONPATH/$PATH for subsequent
     # buildpacks during their build phase. If you are writing a buildpack that
     # needs site-packages during its build process, this flag should be
     # set to true.
     build = true
 
     # Setting the launch flag to true will ensure that the site-packages
-    # dependency is available on the $PYTHONUSERBASE/$PATH for the running
+    # dependency is available on the $PYTHONPATH/$PATH for the running
     # application. If you are writing an application that needs site-packages
     # at runtime, this flag should be set to true.
     launch = true

--- a/fakes/entry_resolver.go
+++ b/fakes/entry_resolver.go
@@ -8,7 +8,7 @@ import (
 
 type EntryResolver struct {
 	MergeLayerTypesCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Name    string
@@ -23,8 +23,8 @@ type EntryResolver struct {
 }
 
 func (f *EntryResolver) MergeLayerTypes(param1 string, param2 []packit.BuildpackPlanEntry) (bool, bool) {
-	f.MergeLayerTypesCall.Lock()
-	defer f.MergeLayerTypesCall.Unlock()
+	f.MergeLayerTypesCall.mutex.Lock()
+	defer f.MergeLayerTypesCall.mutex.Unlock()
 	f.MergeLayerTypesCall.CallCount++
 	f.MergeLayerTypesCall.Receives.Name = param1
 	f.MergeLayerTypesCall.Receives.Entries = param2

--- a/fakes/executable.go
+++ b/fakes/executable.go
@@ -8,7 +8,7 @@ import (
 
 type Executable struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Execution pexec.Execution
@@ -21,8 +21,8 @@ type Executable struct {
 }
 
 func (f *Executable) Execute(param1 pexec.Execution) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.Execution = param1
 	if f.ExecuteCall.Stub != nil {

--- a/fakes/install_process.go
+++ b/fakes/install_process.go
@@ -8,7 +8,7 @@ import (
 
 type InstallProcess struct {
 	ExecuteCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			WorkingDir  string
@@ -23,8 +23,8 @@ type InstallProcess struct {
 }
 
 func (f *InstallProcess) Execute(param1 string, param2 packit.Layer, param3 packit.Layer) error {
-	f.ExecuteCall.Lock()
-	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
 	f.ExecuteCall.CallCount++
 	f.ExecuteCall.Receives.WorkingDir = param1
 	f.ExecuteCall.Receives.TargetLayer = param2

--- a/fakes/parser.go
+++ b/fakes/parser.go
@@ -4,7 +4,7 @@ import "sync"
 
 type Parser struct {
 	ParseVersionCall struct {
-		sync.Mutex
+		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
 			Path string
@@ -18,8 +18,8 @@ type Parser struct {
 }
 
 func (f *Parser) ParseVersion(param1 string) (string, error) {
-	f.ParseVersionCall.Lock()
-	defer f.ParseVersionCall.Unlock()
+	f.ParseVersionCall.mutex.Lock()
+	defer f.ParseVersionCall.mutex.Unlock()
 	f.ParseVersionCall.CallCount++
 	f.ParseVersionCall.Receives.Path = param1
 	if f.ParseVersionCall.Stub != nil {

--- a/fakes/site_packages_process.go
+++ b/fakes/site_packages_process.go
@@ -1,0 +1,29 @@
+package fakes
+
+import "sync"
+
+type SitePackagesProcess struct {
+	ExecuteCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			LayerPath string
+		}
+		Returns struct {
+			SitePackagesPath string
+			Err              error
+		}
+		Stub func(string) (string, error)
+	}
+}
+
+func (f *SitePackagesProcess) Execute(param1 string) (string, error) {
+	f.ExecuteCall.mutex.Lock()
+	defer f.ExecuteCall.mutex.Unlock()
+	f.ExecuteCall.CallCount++
+	f.ExecuteCall.Receives.LayerPath = param1
+	if f.ExecuteCall.Stub != nil {
+		return f.ExecuteCall.Stub(param1)
+	}
+	return f.ExecuteCall.Returns.SitePackagesPath, f.ExecuteCall.Returns.Err
+}

--- a/fakes/venv_dir_locator.go
+++ b/fakes/venv_dir_locator.go
@@ -1,0 +1,29 @@
+package fakes
+
+import "sync"
+
+type VenvDirLocator struct {
+	LocateVenvDirCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Path string
+		}
+		Returns struct {
+			VenvDir string
+			Err     error
+		}
+		Stub func(string) (string, error)
+	}
+}
+
+func (f *VenvDirLocator) LocateVenvDir(param1 string) (string, error) {
+	f.LocateVenvDirCall.mutex.Lock()
+	defer f.LocateVenvDirCall.mutex.Unlock()
+	f.LocateVenvDirCall.CallCount++
+	f.LocateVenvDirCall.Receives.Path = param1
+	if f.LocateVenvDirCall.Stub != nil {
+		return f.LocateVenvDirCall.Stub(param1)
+	}
+	return f.LocateVenvDirCall.Returns.VenvDir, f.LocateVenvDirCall.Returns.Err
+}

--- a/init_test.go
+++ b/init_test.go
@@ -14,5 +14,7 @@ func TestUnitPipenvInstall(t *testing.T) {
 	suite("InstallProcess", testInstallProcess)
 	suite("LockParser", testLockParser)
 	suite("PipfileParser", testPipfileParser)
+	suite("SitePackagesProcess", testSiteProcess)
+	suite("VenvLocator", testVenvLocator)
 	suite.Run(t)
 }

--- a/install_process_test.go
+++ b/install_process_test.go
@@ -27,8 +27,9 @@ func testInstallProcess(t *testing.T, context spec.G, it spec.S) {
 		packagesLayerPath string
 		cacheLayerPath    string
 		workingDir        string
-		executions        []pexec.Execution
-		executable        *fakes.Executable
+
+		executions []pexec.Execution
+		executable *fakes.Executable
 
 		pipenvInstallProcess pipenvinstall.PipenvInstallProcess
 	)
@@ -96,12 +97,6 @@ func testInstallProcess(t *testing.T, context spec.G, it spec.S) {
 				Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement("PIP_USER=1"))
 				Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement(fmt.Sprintf("WORKON_HOME=%s", packagesLayerPath)))
 				Expect(executable.ExecuteCall.Receives.Execution.Env).To(ContainElement(fmt.Sprintf("PIPENV_CACHE_DIR=%s", cacheLayerPath)))
-
-				Expect(packagesLayer.SharedEnv).To(Equal(packit.Environment{
-					"PATH.prepend":           filepath.Join(packagesLayerPath, "some-virtualenv-dir", "bin"),
-					"PATH.delim":             ":",
-					"PYTHONUSERBASE.default": filepath.Join(packagesLayerPath, "some-virtualenv-dir"),
-				}))
 			})
 		})
 
@@ -132,12 +127,6 @@ func testInstallProcess(t *testing.T, context spec.G, it spec.S) {
 				Expect(executions[1].Env).To(ContainElement("PIP_USER=1"))
 				Expect(executions[1].Env).To(ContainElement(fmt.Sprintf("WORKON_HOME=%s", packagesLayerPath)))
 				Expect(executions[1].Env).To(ContainElement(fmt.Sprintf("PIPENV_CACHE_DIR=%s", cacheLayerPath)))
-
-				Expect(packagesLayer.SharedEnv).To(Equal(packit.Environment{
-					"PATH.prepend":           filepath.Join(packagesLayerPath, "some-virtualenv-dir", "bin"),
-					"PATH.delim":             ":",
-					"PYTHONUSERBASE.default": filepath.Join(packagesLayerPath, "some-virtualenv-dir"),
-				}))
 			})
 		})
 

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -80,8 +80,8 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			))
 			Expect(logs).To(ContainLines(
 				"  Configuring environment",
-				MatchRegexp(fmt.Sprintf(`    PATH           -> "/layers/%s/packages/[\w_-]+/bin:\$PATH"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
-				MatchRegexp(fmt.Sprintf(`    PYTHONUSERBASE -> "/layers/%s/packages/[\w_-]+"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
+				MatchRegexp(fmt.Sprintf(`    PATH       -> "/layers/%s/packages/[\w_-]+/bin:\$PATH"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
+				MatchRegexp(fmt.Sprintf(`    PYTHONPATH -> "/layers/%s/packages/lib/python\d+\.\d+/site-packages:\$PYTHONPATH"`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))),
 			))
 			Expect(logs).To(ContainLines(
 				// Due to Pipfile requirement

--- a/run/main.go
+++ b/run/main.go
@@ -14,7 +14,10 @@ import (
 func main() {
 	planner := draft.NewPlanner()
 	logger := scribe.NewEmitter(os.Stdout)
-	installProcess := pipenvinstall.NewPipenvInstallProcess(pexec.NewExecutable("pipenv"), logger)
+	installProcess := pipenvinstall.NewPipenvInstallProcess(
+		pexec.NewExecutable("pipenv"),
+		logger,
+	)
 	pipfileParser := pipenvinstall.NewPipfileParser()
 	lockParser := pipenvinstall.NewPipfileLockParser()
 
@@ -26,6 +29,8 @@ func main() {
 		pipenvinstall.Build(
 			planner,
 			installProcess,
+			pipenvinstall.NewSiteProcess(pexec.NewExecutable("python")),
+			pipenvinstall.NewVenvLocator(),
 			chronos.DefaultClock,
 			logger,
 		),

--- a/site_process.go
+++ b/site_process.go
@@ -1,0 +1,45 @@
+package pipenvinstall
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+)
+
+// SiteProcess implements the Executable interface.
+type SiteProcess struct {
+	executable Executable
+}
+
+// NewSiteProcess creates an instance of the SiteProcess given an Executable that runs `python`
+func NewSiteProcess(executable Executable) SiteProcess {
+	return SiteProcess{
+		executable: executable,
+	}
+}
+
+// Execute runs a python command to locate the site packages within the pip targetLayerPath.
+func (p SiteProcess) Execute(layerPath string) (string, error) {
+	buffer := bytes.NewBuffer(nil)
+
+	err := p.executable.Execute(pexec.Execution{
+		Args:   []string{"-m", "site", "--user-site"},
+		Env:    append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", layerPath)),
+		Stdout: buffer,
+		Stderr: buffer,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to locate site packages:\n%s\nerror: %w", buffer.String(), err)
+	}
+
+	path := strings.TrimSpace(buffer.String())
+
+	if len(path) == 0 {
+		return "", fmt.Errorf("failed to locate site packages: output is empty")
+	}
+
+	return path, nil
+}

--- a/site_process_test.go
+++ b/site_process_test.go
@@ -1,0 +1,92 @@
+package pipenvinstall_test
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/pexec"
+	"github.com/paketo-buildpacks/pipenv-install/fakes"
+	pipenvinstall "github.com/paketo-buildpacks/pipenv-install"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testSiteProcess(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		layerPath  string
+		executable *fakes.Executable
+
+		process pipenvinstall.SiteProcess
+	)
+
+	it.Before(func() {
+		var err error
+		layerPath, err = ioutil.TempDir("", "layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		executable = &fakes.Executable{}
+		executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+			if execution.Stdout != nil {
+				fmt.Fprintln(execution.Stdout, filepath.Join(layerPath, "/pip/lib/python/site-packages"))
+			}
+			return nil
+		}
+
+		process = pipenvinstall.NewSiteProcess(executable)
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(layerPath)).To(Succeed())
+	})
+
+	context("Execute", func() {
+		context("there are site packages in the pipenv layer", func() {
+			it("returns the full path to the packages", func() {
+				sitePackagesPath, err := process.Execute(layerPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(executable.ExecuteCall.Receives.Execution.Env).To(Equal(append(os.Environ(), fmt.Sprintf("PYTHONUSERBASE=%s", layerPath))))
+				Expect(executable.ExecuteCall.Receives.Execution.Args).To(Equal([]string{"-m", "site", "--user-site"}))
+
+				Expect(sitePackagesPath).To(Equal(filepath.Join(layerPath, "pip", "lib", "python", "site-packages")))
+			})
+		})
+
+		context("failure cases", func() {
+			context("site package lookup fails", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
+						fmt.Fprintln(execution.Stdout, "stdout output")
+						fmt.Fprintln(execution.Stderr, "stderr output")
+						return errors.New("locating site packages failed")
+					}
+				})
+
+				it("returns an error", func() {
+					_, err := process.Execute(layerPath)
+					Expect(err).To(MatchError(ContainSubstring("failed to locate site packages:")))
+					Expect(err).To(MatchError(ContainSubstring("stderr output")))
+					Expect(err).To(MatchError(ContainSubstring("error: locating site packages failed")))
+				})
+			})
+
+			context("when the site process returns nothing", func() {
+				it.Before(func() {
+					executable.ExecuteCall.Stub = nil
+				})
+
+				it("returns an error", func() {
+					_, err := process.Execute(layerPath)
+					Expect(err).To(MatchError("failed to locate site packages: output is empty"))
+				})
+			})
+		})
+	})
+}

--- a/venv_locator.go
+++ b/venv_locator.go
@@ -1,0 +1,50 @@
+package pipenvinstall
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/paketo-buildpacks/packit"
+)
+
+type VenvLocator struct {
+}
+
+func NewVenvLocator() VenvLocator {
+	return VenvLocator{}
+}
+
+// It would have been cleaner to run "pipenv --venv"
+// and extract out the exact virtual env dir,
+// but it doesn't seem to work.
+// So we look for the dir with pyvenv.cfg in $WORKON_HOME
+
+func (v VenvLocator) LocateVenvDir(path string) (string, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return "", packit.Fail.WithMessage("reading target directory %s failed:\nerror: %w", path, err)
+	}
+
+	venvDir := ""
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		_, err := os.Stat(filepath.Join(path, entry.Name(), "pyvenv.cfg"))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", packit.Fail.WithMessage("pipenv virtual env dir lookup failed in target %s: %w", path, err)
+		}
+		venvDir = entry.Name()
+		break
+	}
+
+	if venvDir == "" {
+		return "", packit.Fail.WithMessage("pipenv virtual env directory not found in target %s", path)
+	}
+
+	return filepath.Join(path, venvDir), nil
+}

--- a/venv_locator_test.go
+++ b/venv_locator_test.go
@@ -1,0 +1,99 @@
+package pipenvinstall_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pipenvinstall "github.com/paketo-buildpacks/pipenv-install"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testVenvLocator(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		layerPath string
+
+		process pipenvinstall.VenvLocator
+	)
+
+	it.Before(func() {
+		var err error
+		layerPath, err = ioutil.TempDir("", "layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.Mkdir(filepath.Join(layerPath, "some-virtualenv-dir"), os.ModePerm)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(layerPath, "some-virtualenv-dir", "pyvenv.cfg"), nil, os.ModePerm)).To(Succeed())
+
+		Expect(os.Mkdir(filepath.Join(layerPath, "some-other-dir"), os.ModePerm)).To(Succeed())
+
+		process = pipenvinstall.NewVenvLocator()
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(layerPath)).To(Succeed())
+	})
+
+	context("LocateVenvDir", func() {
+		it("returns the full path to the packages", func() {
+			venvDir, err := process.LocateVenvDir(layerPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(venvDir).To(Equal(filepath.Join(layerPath, "some-virtualenv-dir")))
+		})
+
+		context("failure cases", func() {
+			context("when reading the root directory fails", func() {
+				it.Before(func() {
+					Expect(os.Chmod(layerPath, 0000)).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Chmod(layerPath, os.ModePerm)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := process.LocateVenvDir(layerPath)
+					Expect(err).To(MatchError(ContainSubstring("permission denied")))
+				})
+			})
+
+			context("when reading a subdirectory fails", func() {
+				it.Before(func() {
+					Expect(os.Chmod(filepath.Join(layerPath, "some-virtualenv-dir"), 0000)).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Chmod(filepath.Join(layerPath, "some-virtualenv-dir"), os.ModePerm)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := process.LocateVenvDir(layerPath)
+					Expect(err).To(MatchError(ContainSubstring("lookup failed")))
+				})
+			})
+
+			context("when there is no virtual env directory", func() {
+				var emptyLayerPath string
+				it.Before(func() {
+					var err error
+					emptyLayerPath, err = ioutil.TempDir("", "layer")
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it.After(func() {
+					Expect(os.RemoveAll(emptyLayerPath)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := process.LocateVenvDir(emptyLayerPath)
+					Expect(err).To(MatchError(ContainSubstring("virtual env directory not found")))
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
- Doing this will allow other buildpacks to use PYTHONUSERBASE without
  breaking the environment setup by this buildpack, as assigning
  PYTHONUSERBASE in this buildpack prevents subsequent buildpacks from
  adding modules to the application.

Closes #54 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
