### PR TITLE
Removes built_at

### DIFF
--- a/build.go
+++ b/build.go
@@ -123,10 +123,6 @@ func Build(
 		logger.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(packagesLayer.SharedEnv))
 		logger.Break()
 
-		packagesLayer.Metadata = map[string]interface{}{
-			"built_at": clock.Now().Format(time.RFC3339Nano),
-		}
-
 		layers := []packit.Layer{packagesLayer}
 		if _, err := os.Stat(cacheLayer.Path); err == nil {
 			if !fs.IsEmptyDir(cacheLayer.Path) {

--- a/build_test.go
+++ b/build_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
@@ -29,8 +28,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		workingDir string
 		cnbDir     string
 
-		clock      chronos.Clock
-		timeStamp  time.Time
 		buffer     *bytes.Buffer
 		logEmitter scribe.Emitter
 
@@ -68,18 +65,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 		logEmitter = scribe.NewEmitter(buffer)
 
-		timeStamp = time.Now()
-		clock = chronos.NewClock(func() time.Time {
-			return timeStamp
-		})
-
 		build = pipenvinstall.Build(
 			entryResolver,
 			installProcess,
 			sitePackagesProcess,
 			venvDirLocator,
 			sbomGenerator,
-			clock,
+			chronos.DefaultClock,
 			logEmitter)
 
 		buildContext = packit.BuildContext{
@@ -132,9 +124,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(packagesLayer.SharedEnv["PATH.delim"]).To(Equal(":"))
 		Expect(packagesLayer.SharedEnv["PYTHONPATH.prepend"]).To(Equal("some-site-packages-path"))
 		Expect(packagesLayer.SharedEnv["PYTHONPATH.delim"]).To(Equal(":"))
-
-		Expect(packagesLayer.Metadata).To(HaveLen(1))
-		Expect(packagesLayer.Metadata["built_at"]).To(Equal(timeStamp.Format(time.RFC3339Nano)))
 
 		Expect(packagesLayer.SBOM.Formats()).To(Equal([]packit.SBOMFormat{
 			{


### PR DESCRIPTION
Resolves #110

This buildpack currently does not reuse a layer but the `built_at` tag has still been removed for consistency sake.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
