### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pipenv Install Cloud Native Buildpack
-The Paketo Pipenv Install Buildpack is a Cloud Native Buildpack that installs
+The Paketo Buildpack for Pipenv Install is a Cloud Native Buildpack that installs
 packages using pipenv and makes it available to the application.
 
 The buildpack is published for consumption at

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/pipenv-install"
-  name = "Paketo Pipenv Install Buildpack"
+  name = "Paketo Buildpack for Pipenv Install"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Pipenv Install Buildpack' to 'Paketo Buildpack for Pipenv Install'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
