### PR TITLE
Pin werkzeug version to last version compatible with Flask 2

### DIFF
--- a/integration/testdata/default_app/Pipfile
+++ b/integration/testdata/default_app/Pipfile
@@ -5,6 +5,7 @@ name = "default_app"
 
 [packages]
 Flask = "==2.1.3"
+Werkzeug = "==2.3.7"
 gunicorn = "*"
 
 [dev-packages]


### PR DESCRIPTION

## Summary
<!-- A short explanation of the proposed change -->
Werkzeug has released v3.0.0, which appears to be incompatible with Flask 2.1.3. Flask, however, still automatically pulls the new version in as a dependency. This PR simply pins Werkzeug to the last compatible version. ([source](https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls))

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
